### PR TITLE
Attempted command queue workaround

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "arduino.logLevel": "verbose"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "arduino.logLevel": "verbose"
-}

--- a/blackout.ino
+++ b/blackout.ino
@@ -100,7 +100,7 @@ struct CommandAndData
   byte data : 4;
 };
 
-#define COMM_QUEUE_SIZE 4
+#define COMM_QUEUE_SIZE 8
 CommandAndData commQueues[FACE_COUNT][COMM_QUEUE_SIZE];
 
 #define COMM_INDEX_ERROR_OVERRUN 0xFF
@@ -596,14 +596,12 @@ void __attribute__((noinline)) enqueueCommOnFace(byte f, Command command, byte d
     return;
   }
 
-/*
   if (commInsertionIndexes[f] >= COMM_QUEUE_SIZE)
   {
     // Buffer overrun - might need to increase queue size to accommodate
-    commInsertionIndexes[f] = COMM_INDEX_ERROR_OVERRUN;
+//    commInsertionIndexes[f] = COMM_INDEX_ERROR_OVERRUN;
     return;
   }
-*/
 
   byte index = commInsertionIndexes[f];
   commQueues[f][index].command = command;


### PR DESCRIPTION
I did two things to try to work around the issue L.C. is seeing.

First, I doubled the command queue size from 4 to 8 per face. If his issue was a simple queue overrun then this should address it. Since I have not seen his failure locally I am worried it's specific to his setup and this might not be a permanent fix.

Second, I uncommented some code I had removed to save code space. This code checks if the queue is full and prevents further commands from being added. Hopefully, should the problem happen again, it allows the game to be reset properly by long press.