### PR TITLE
Bug and quality of life fixes

### DIFF
--- a/blackout.ino
+++ b/blackout.ino
@@ -868,9 +868,7 @@ void processCommForFace(Command command, byte value, byte f)
       break;
       
     case Command_ToolColor:
-#if REDUNDANT_ROLE_CHECKS
       if (tileRole == TileRole_Working)
-#endif
       {
         faceStatesGame[f].neighborTool.color = value;
         updateWorkingState();

--- a/blackout.ino
+++ b/blackout.ino
@@ -509,10 +509,13 @@ void handleUserInput()
     }
   }
 
-  // No matter what state we're in, long pressing resets the game and other connected tiles
-  if (buttonLongPressed())
+  // No matter what state we're in, triple click resets the game and other connected tiles
+  if (buttonMultiClicked())
   {
-    resetGame();
+    if (buttonClickCount() == 3)
+    {
+      resetGame();
+    }
   }
 }
 

--- a/blackout.ino
+++ b/blackout.ino
@@ -764,13 +764,11 @@ void processCommForFace(Command command, byte value, byte f)
   {
     case Command_AssignRole:
       // Grab our new role
-      tileRole = (TileRole) value;
-      rootFace = f;
-      gameState = GameState_Setup;
-#if REDUNDANT_ROLE_CHECKS
-      if (tileRole == TileRole_Tool)
-#endif
+      if (tileRole != TileRole_Working)
       {
+        tileRole = (TileRole) value;
+        rootFace = f;
+        gameState = GameState_Setup;
         showAnimation(ANIM_SEQ_INDEX__TOOL_SETUP, ANIM_RATE_SLOW);
       }
       break;

--- a/blinklib.cpp
+++ b/blinklib.cpp
@@ -629,6 +629,7 @@ static void RX_IRFaces() {
                             if ( packetDataLen == 2 && decodedByte == TRIGGER_WARM_SLEEP_SPECIAL_VALUE && packetData[1] == TRIGGER_WARM_SLEEP_SPECIAL_VALUE ) {
                                 
                                 warm_sleep_cycle();                                
+                                blinkbios_button_block.bitflags = 0;
                                 
                             }
                             

--- a/blinklib.cpp
+++ b/blinklib.cpp
@@ -171,14 +171,14 @@ struct face_t {
     
     uint8_t inDatagramLen;  // 0= No datagram waiting to be read
 #if 1
-    uint8_t inDatagramData[8];
+    uint8_t inDatagramData[1];
 #else
     uint8_t inDatagramData[IR_DATAGRAM_LEN];
 #endif
 
     uint8_t outDatagramLen;  // 0= No datagram waiting to be sent
 #if 1
-    uint8_t outDatagramData[8];
+    uint8_t outDatagramData[1];
 #else
     uint8_t outDatagramData[IR_DATAGRAM_LEN];
 #endif


### PR DESCRIPTION
* Reduced datagram size further in blinklib.cpp to give Dispel more data space just in case.
* Fix bug where a game with a single rune tile wouldn't work.
* Better handle game reset so the tiles still reset even when in the bad state seen by L.C.
* QOL: Change reset from long press to triple click. Player can now manually sleep the game without resetting.
* QOL: Waking the cluster by clicking a tile different from the one that put them to sleep will properly swallow the click.